### PR TITLE
Add the missing artwork for yt-2400-light-freighter.json

### DIFF
--- a/data/pilots/rebel-alliance/yt-2400-light-freighter.json
+++ b/data/pilots/rebel-alliance/yt-2400-light-freighter.json
@@ -163,7 +163,7 @@
         "Modification",
         "Title"
       ],
-      "artwork": "",
+      "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/leebo-wisdomofages.png",
       "image": "https://infinitearenas.com/xw2/images/pilots/leebo-wisdomofages.png",
       "standard": true,
       "extended": true,
@@ -192,7 +192,7 @@
         "Modification",
         "Title"
       ],
-      "artwork": "",
+      "artwork": "https://infinitearenas.com/xw2/images/artwork/pilots/dashrendar-freighterforhire.png",
       "image": "https://infinitearenas.com/xw2/images/pilots/dashrendar-freighterforhire.png",
       "standard": true,
       "extended": true,


### PR DESCRIPTION
Note these XWS names don't match the URLs but the artwork matches the card image